### PR TITLE
Fix Header Box transform style

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -71,7 +71,7 @@ const Header = () => {
       top={0}
       left={0}
       right={0}
-      translateY={0}
+      transform="translateY(0)"
       transitionProperty="transform"
       transitionDuration=".3s"
       transitionTimingFunction="ease-in-out"


### PR DESCRIPTION
## Summary
- use `transform="translateY(0)"` to initialize header position

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685ef96aa1a083268220a8f4eb82ed46