### PR TITLE
Fix infinite alert loop

### DIFF
--- a/src/components/ContactMeSection.js
+++ b/src/components/ContactMeSection.js
@@ -50,7 +50,7 @@ const LandingSection = () => {
         formik.resetForm();
       }
     }
-  }, [response, onOpen]);
+  }, [response]);
 
   return (
     <FullScreenSection

--- a/src/context/alertContext.js
+++ b/src/context/alertContext.js
@@ -1,4 +1,4 @@
-import {createContext, useContext, useState} from "react";
+import {createContext, useContext, useState, useCallback} from "react";
 
 const AlertContext = createContext(undefined);
 
@@ -11,12 +11,20 @@ export const AlertProvider = ({ children }) => {
     message: '',
   });
 
+  const onOpen = useCallback((type, message) => {
+    setState({ isOpen: true, type, message });
+  }, []);
+
+  const onClose = useCallback(() => {
+    setState({ isOpen: false, type: '', message: '' });
+  }, []);
+
   return (
     <AlertContext.Provider
       value={{
         ...state,
-        onOpen: (type, message) => setState({ isOpen: true, type, message }),
-        onClose: () => setState({ isOpen: false, type: '', message: '' }),
+        onOpen,
+        onClose,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- memoize `onOpen`/`onClose` in `alertContext`
- call alert effect when only `response` changes

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_685ef95a3ee883269c732b7e9f975689